### PR TITLE
Add topic model training functionality with fixed hyperparameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ models/
 # Real config files
 config/config.yml
 config/stopwords.txt
+config/test/
 
 # Notebooks
 notebooks/

--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,8 @@ log/
 models/
 
 # Real config files
-config/config.yml
+config/hpt_config.yml
+config/inference_config.yml
 config/stopwords.txt
 config/test/
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ poetry run python main.py -c config/hpt_config.yml -p 0
 
 ### Inference
 * Place the data CSV file to perform inference on under `data/`. As with training, ensure the file has `note_id` and `full_note_norm` columns. Point the `data_file` option to this file within the configuration YAML.
-* Point `model_file` option to the serialized model file under `models/`.
-* Topics require human interpretation, edit the topics file under `models/` or leave as the default names. Point the `topics_file` option to this file.
+* Point `model_file` option to the serialized model file under the output directory in the previous step.
+* Topics require human interpretation, edit the topics file under the same output directory in the previous step or leave as the default names. Point the `topics_file` option to this file.
 Similar to training, run `topic.py` with Poetry.
 ```sh
 poetry run python topic.py -c config/inference_config.yml

--- a/README.md
+++ b/README.md
@@ -39,19 +39,19 @@ poetry install --no-dev
 * Place your stopwords file under the `config/` folder and point the `stopwords` option within the configuration YAML to this file.
 * Edit the configuration YAML as needed.
 
-### Training
+### Training with Hyperparameter Tuning
 Run `main.py` with Poetry to use the virtualenv.
 ```sh
-poetry run python main.py -c config/config.yml -p 0
+poetry run python main.py -c config/hpt_config.yml -p 0
 ```
 
 ### Inference
-* Place the data CSV file to perform inference on under `data/`. As with training, ensure the file has `note_id` and `full_note_norm` columns. Point the `raw_data` option to this file within the configuration YAML.
+* Place the data CSV file to perform inference on under `data/`. As with training, ensure the file has `note_id` and `full_note_norm` columns. Point the `data_file` option to this file within the configuration YAML.
 * Point `model_file` option to the serialized model file under `models/`.
 * Topics require human interpretation, edit the topics file under `models/` or leave as the default names. Point the `topics_file` option to this file.
 Similar to training, run `topic.py` with Poetry.
 ```sh
-poetry run python topic.py -c config/config.yml
+poetry run python topic.py -c config/inference_config.yml
 ```
 
 ## Built With

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Run `main.py` with Poetry to use the virtualenv.
 poetry run python main.py -c config/hpt_config.yml -p 0
 ```
 
+### Training with Fixed Hyperparameters
+Run `single_fit.py` with Poetry.
+Hyperparameters should be specified in its own YAML file. If previously generated through hyperparameter tuning, this file will be located within the previous output directory.
+```sh
+poetry run python single_fit.py -c config/single_fit.yml -b best_hyperparameters.yml
+```
+
 ### Inference
 * Place the data CSV file to perform inference on under `data/`. As with training, ensure the file has `note_id` and `full_note_norm` columns. Point the `data_file` option to this file within the configuration YAML.
 * Point `model_file` option to the serialized model file under the output directory in the previous step.

--- a/config/example_hpt_config.yml
+++ b/config/example_hpt_config.yml
@@ -1,6 +1,7 @@
 data_file: file.csv
 stopwords: stopwords.txt
 number_of_topic_top_words: 10
+output_dir: models/
 
 tuner:
   trials: 5

--- a/config/example_hpt_config.yml
+++ b/config/example_hpt_config.yml
@@ -2,11 +2,6 @@ data_file: file.csv
 stopwords: stopwords.txt
 number_of_topic_top_words: 10
 
-inference:
-  raw_data: inference_file.csv
-  model_file: model.pkl
-  topics_file: model_topics.tsv
-
 tuner:
   trials: 5
   study:
@@ -42,4 +37,3 @@ lda_hparams:
   offset:
     - 10.0
     - 100.0
-

--- a/config/example_inference_config.yml
+++ b/config/example_inference_config.yml
@@ -1,0 +1,3 @@
+data_file: cll_progress_27k.csv
+model_file: LatentDirichletAllocation.pkl
+topics_file: LatentDirichletAllocation_topics.tsv

--- a/config/example_inference_config.yml
+++ b/config/example_inference_config.yml
@@ -1,3 +1,4 @@
-data_file: cll_progress_27k.csv
-model_file: LatentDirichletAllocation.pkl
-topics_file: LatentDirichletAllocation_topics.tsv
+data_file: inference_file.csv
+model_file: models/model.pkl
+topics_file: models/model_topics.tsv
+output_dir: output/

--- a/config/example_single_fit_config.yml
+++ b/config/example_single_fit_config.yml
@@ -1,0 +1,8 @@
+data_file: file.csv
+stopwords: stopwords.txt
+number_of_topic_top_words: 15
+output_dir: models/no_hpt/
+
+model:
+  seed: 8
+  n_jobs: 1

--- a/ehr_topic_model/util/__init__.py
+++ b/ehr_topic_model/util/__init__.py
@@ -1,1 +1,3 @@
-from .util import coherence, remove_nums, topic_top_words
+from .io import load_data, load_stopwords, save_model, save_topics
+from .util import (coherence, print_model_performance, remove_nums,
+                   topic_top_words)

--- a/ehr_topic_model/util/io.py
+++ b/ehr_topic_model/util/io.py
@@ -1,0 +1,89 @@
+# ehr_topic_model/util/io.py
+
+from pathlib import Path
+from typing import Set
+
+import joblib
+import pandas as pd
+from sklearn.pipeline import Pipeline
+
+from .util import remove_nums
+
+
+def load_data(fpath: Path) -> pd.DataFrame:
+    """
+    Load data from CSV.
+    File should contain columns: `note_id` and `full_note norm`.
+
+    Parameters
+    ----------
+    fpath : pathlib.Path
+        The data CSV file path.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A pandas DataFrame containing the note documents.
+        Note ID serves as the index.
+    """
+    X: pd.DataFrame = pd.read_csv(
+        filepath_or_buffer=fpath,
+        index_col="note_id",
+        usecols=["note_id", "full_note_norm"],
+    )
+    _ = X.apply(func=remove_nums, axis="columns")  # remove numbers from text
+    return X
+
+
+def load_stopwords(fpath: Path) -> Set[str]:
+    """
+    Load stopwords from file.
+
+    Parameters
+    ----------
+    fpath : pathlib.Path
+        The stopwords file.
+
+    Returns
+    -------
+    set of str
+        Set of stopwords.
+    """
+    stopwords: Set[str]
+    line: str
+    with fpath.open() as sw_f:
+        stopwords = {line.rstrip("\n") for line in sw_f}
+    return stopwords
+
+
+def save_topics(topics: str, model_name: str, output_dpath: Path) -> None:
+    """
+    Write topics and top words to TSV file.
+
+    Parameters
+    ----------
+    topics : str
+        Formatted topics string. In the format of "Topic_#:\t{top words}\n".
+    model_name : str
+        The name of the topic model
+    output_dpath : pathlib.Path
+        The output directory.
+    """
+    with Path(output_dpath, "{}_topics.tsv".format(model_name)).open("w") as topic_f:
+        topic_f.write(topics)
+
+
+def save_model(model: Pipeline, model_name: str, output_dpath: Path) -> None:
+    """
+    Save serialized model to disk.
+
+    Parameters
+    ----------
+    model : sklearn.pipeline.Pipeline
+        The fit model to serialize and save to disk.
+    model_name : str
+        The name of the topic model.
+    output_dpath : pathlib.Path
+        The output directory path.
+    """
+    joblib.dump(value=model, filename=Path(output_dpath, "{}.pkl".format(model_name)))

--- a/ehr_topic_model/util/util.py
+++ b/ehr_topic_model/util/util.py
@@ -82,3 +82,22 @@ def topic_top_words(
         output += message + "\n"
     print()  # extra newline for stdout formatting
     return output
+
+
+def print_model_performance(model_name: str, metric_val: float) -> None:
+    """
+    Print model performance metric to stdout.
+
+    Parameters
+    ----------
+    model_name : str
+        The name of the topic model.
+    metric_val : float
+        The performance metric.
+    """
+    print_pad: str = "\n=====\n"  # padding
+    print(
+        "{pad}Model:\t\t\t{model}\nTopic Coherence:\t{metric_val}{pad}".format(
+            pad=print_pad, model=model_name, metric_val=metric_val
+        )
+    )

--- a/main.py
+++ b/main.py
@@ -80,7 +80,6 @@ def _save_topics(topics: str, model_name: str, output_dpath: Path) -> None:
     output_dpath : pathlib.Path
         The output directory.
     """
-    output_dpath.mkdir(exist_ok=True)
     with Path(output_dpath, "{}_topics.tsv".format(model_name)).open("w") as topic_f:
         topic_f.write(topics)
 
@@ -96,6 +95,7 @@ def _score_model(tuner: BaseTuner, output_dpath: Path) -> None:
     output_dpath : pathlib.Path
         The output directory.
     """
+    output_dpath.mkdir(exist_ok=True)
     est: Pipeline = tuner.tune(
         **CONFIG["tuner"]["study"], **CONFIG["tuner"]["optimize"]
     )

--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, Set, Tuple
 
-import joblib
 import pandas as pd
 import yaml
 from sklearn.decomposition import LatentDirichletAllocation
@@ -16,72 +15,12 @@ from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.pipeline import Pipeline
 
 from ehr_topic_model.hpt import BaseTuner, CountVectorizerLdaTuner
-from ehr_topic_model.util import remove_nums, topic_top_words
+from ehr_topic_model.util import (load_data, load_stopwords,
+                                  print_model_performance, save_model,
+                                  save_topics, topic_top_words)
 
 # Global configuration dict.
 CONFIG: Dict[str, Any] = {}
-
-
-def _load_data(dpath: Path) -> pd.Series:
-    """
-    Load data from CSV.
-    File should contain columns: `note_id` and `full_note_norm`.
-
-    Parameters
-    ----------
-    dpath : pathlib.Path
-        The directory containing the data CSV.
-
-    Returns
-    -------
-    pd.Series
-        List of documents.
-    """
-    X: pd.DataFrame = pd.read_csv(
-        filepath_or_buffer=Path(dpath, CONFIG["data_file"]),
-        index_col="note_id",
-        usecols=["note_id", "full_note_norm"],
-    )
-    _ = X.apply(func=remove_nums, axis="columns")  # remove numbers from text
-    return X.iloc[:, 0]
-
-
-def _load_stopwords(dpath: Path) -> Set[str]:
-    """
-    Load stopwords from file.
-
-    Parameters
-    ----------
-    dpath : pathlib.Path
-       The directory containing the stopwords file.
-
-    Returns
-    -------
-    list of str
-        Array of stopwords.
-    """
-    stopwords: Set[str]
-    line: str
-    with Path(dpath, CONFIG["stopwords"]).open() as sw_f:
-        stopwords = {line.rstrip("\n") for line in sw_f}
-    return stopwords
-
-
-def _save_topics(topics: str, model_name: str, output_dpath: Path) -> None:
-    """
-    Write topics and top words to TSV file.
-
-    Parameters
-    ----------
-    topics : str
-        Formatted topics string. In the format of "Topic_#:\t{top words}\n"
-    model_name : str
-        The name of the topic model.
-    output_dpath : pathlib.Path
-        The output directory.
-    """
-    with Path(output_dpath, "{}_topics.tsv".format(model_name)).open("w") as topic_f:
-        topic_f.write(topics)
 
 
 def _score_model(tuner: BaseTuner, output_dpath: Path) -> None:
@@ -95,20 +34,12 @@ def _score_model(tuner: BaseTuner, output_dpath: Path) -> None:
     output_dpath : pathlib.Path
         The output directory.
     """
-    output_dpath.mkdir(exist_ok=True)
     est: Pipeline = tuner.tune(
         **CONFIG["tuner"]["study"], **CONFIG["tuner"]["optimize"]
     )
     model_name: str = est[-1].__class__.__name__
     tuner.save_and_print_best_hparams(dpath=output_dpath, model_name=model_name)
-
-    # Printing topic model and evaluation metric value to stdout.
-    print_pad: str = "\n=====\n"  # padding
-    print(
-        "{pad}Model:\t\t\t{model}\nTopic Coherence:\t{metric_val}{pad}".format(
-            pad=print_pad, model=model_name, metric_val=tuner.study.best_value
-        )
-    )
+    print_model_performance(model_name=model_name, metric_val=tuner.study.best_value)
 
     # Printing topics and top words to stdout.
     # Formatted topic string is extracted to write to file.
@@ -117,12 +48,11 @@ def _score_model(tuner: BaseTuner, output_dpath: Path) -> None:
         feature_names=est[0].get_feature_names(),
         n_top_words=CONFIG["number_of_topic_top_words"],
     )
-    _save_topics(
+    output_dpath.mkdir(exist_ok=True)
+    save_topics(
         topics=fmt_topics_topwords, model_name=model_name, output_dpath=output_dpath
     )
-
-    # Writing serialized model to disk.
-    joblib.dump(value=est, filename=Path(output_dpath, "{}.pkl".format(model_name)))
+    save_model(model=est, model_name=model_name, output_dpath=output_dpath)
 
 
 def main(pipeline_idx: int) -> None:
@@ -144,8 +74,10 @@ def main(pipeline_idx: int) -> None:
         )
 
     project_home: Path = Path(__file__).parent
-    X: pd.Series = _load_data(Path(project_home, "data"))
-    custom_stopwords: Set[str] = _load_stopwords(Path(project_home, "config"))
+    X: pd.Series = load_data(Path(project_home, "data", CONFIG["data_file"])).iloc[:, 0]
+    custom_stopwords: Set[str] = load_stopwords(
+        Path(project_home, "config", CONFIG["stopwords"])
+    )
 
     # Initialize tuner objects, ordered by index.
     tuners: Tuple[BaseTuner, ...] = (
@@ -166,7 +98,10 @@ def main(pipeline_idx: int) -> None:
         ),
     )
 
-    _score_model(tuner=tuners[pipeline_idx], output_dpath=Path(project_home, "models"))
+    _score_model(
+        tuner=tuners[pipeline_idx],
+        output_dpath=Path(project_home, CONFIG["output_dir"]),
+    )
 
 
 # CLI

--- a/single_fit.py
+++ b/single_fit.py
@@ -1,0 +1,138 @@
+# single_fit.py
+
+import sys
+from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
+from pathlib import Path
+from textwrap import dedent
+from typing import Any, Dict, Set, Tuple
+
+import pandas as pd
+import yaml
+from sklearn.decomposition import LatentDirichletAllocation
+from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.pipeline import Pipeline
+
+from ehr_topic_model.util import (coherence, load_data, load_stopwords,
+                                  print_model_performance, save_model,
+                                  save_topics, topic_top_words)
+
+SINGLE_FIT_CONFIG: Dict[str, Any] = {}
+BEST_HYPERPARAMETERS: Dict[str, Any] = {}
+
+
+def _fit_pipeline(project_home: Path, pipeline: Pipeline, X: pd.Series) -> None:
+    """
+    Set pipeline hyperparameters, fit to data, and save to disk.
+
+    Parameters
+    ----------
+    project_home : pathlib.Path
+        Project home directory.
+    pipeline : sklearn.pipeline.Pipeline
+        Topic model pipeline.
+    X : pandas.Series
+        Data.
+    """
+    pipeline.set_params(**BEST_HYPERPARAMETERS).fit(X)
+    model_name: str = pipeline[-1].__class__.__name__
+    metric_val: float = coherence(pipeline=pipeline, X=X)
+    print_model_performance(model_name=model_name, metric_val=metric_val)
+    fmt_topics_topwords: str = topic_top_words(
+        model=pipeline[1],
+        feature_names=pipeline[0].get_feature_names(),
+        n_top_words=SINGLE_FIT_CONFIG["number_of_topic_top_words"],
+    )
+    output_dpath: Path = Path(project_home, SINGLE_FIT_CONFIG["output_dir"])
+    output_dpath.mkdir(exist_ok=True)
+    save_topics(
+        topics=fmt_topics_topwords, model_name=model_name, output_dpath=output_dpath,
+    )
+    save_model(model=pipeline, model_name=model_name, output_dpath=output_dpath)
+
+
+def main(pipeline_idx: int) -> None:
+    """
+    Train topic model on fixed hyperparameters.
+
+    Parameters
+    ----------
+    pipeline_idx : int
+        Index of pipeline to use.
+    """
+    # Exit program if pipeline_idx = 1 as tfidf+NMF hasn't been implemented yet.
+    if pipeline_idx == 1:
+        sys.exit(
+            (
+                "The TF-IDF + NMF pipeline hasn't been implemented yet, sorry! "
+                "Please rerun the program with --pipeline set to 0."
+            )
+        )
+
+    project_home: Path = Path(__file__).parent
+    X: pd.Series = load_data(
+        Path(project_home, "data", SINGLE_FIT_CONFIG["data_file"])
+    ).iloc[:, 0]
+    custom_stopwords: Set[str] = load_stopwords(
+        Path(project_home, "config", SINGLE_FIT_CONFIG["stopwords"])
+    )
+
+    # Initialize pipelines, ordered by index.
+    pipelines: Tuple[Pipeline, ...] = (
+        Pipeline(
+            [
+                ("vect", CountVectorizer(stop_words=custom_stopwords)),
+                (
+                    "decomp",
+                    LatentDirichletAllocation(
+                        random_state=SINGLE_FIT_CONFIG["model"]["seed"],
+                        n_jobs=SINGLE_FIT_CONFIG["model"]["n_jobs"],
+                    ),
+                ),
+            ]
+        ),
+    )
+
+    _fit_pipeline(project_home=project_home, pipeline=pipelines[pipeline_idx], X=X)
+
+
+if __name__ == "__main__":
+    parser: ArgumentParser = ArgumentParser(
+        description="Train topic models on EHR notes with set hyperparameters.",
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        default=None,
+        type=str,
+        help="Configuration YAML file path (default: None)",
+    )
+    parser.add_argument(
+        "-b",
+        "--best_hyperparameters",
+        default=None,
+        type=str,
+        help="Best hyperparameters YAML file path (default: None)",
+    )
+    parser.add_argument(
+        "-p",
+        "--pipeline",
+        choices={0, 1},
+        type=int,
+        default=0,
+        help=dedent(
+            """\
+            Topic modeling pipeline (default: 0)
+            0 -> Term Counts + Latent Dirichlet Allocation
+            1 -> TF-IDF + Non-negative Matrix Factorization
+            """
+        ),
+    )
+
+    args: Namespace = parser.parse_args()
+    with Path(args.config).open() as config_f:
+        SINGLE_FIT_CONFIG = yaml.load(stream=config_f, Loader=yaml.FullLoader)
+    with Path(args.best_hyperparameters).open() as bhp_f:
+        BEST_HYPERPARAMETERS = yaml.load(stream=bhp_f, Loader=yaml.FullLoader)
+
+    main(pipeline_idx=args.pipeline)

--- a/topic.py
+++ b/topic.py
@@ -74,7 +74,7 @@ def _load_inference_data(dpath: Path) -> pd.DataFrame:
         A pandas dataframe containing the notes. Note ID serves as the index.
     """
     X: pd.DataFrame = pd.read_csv(
-        filepath_or_buffer=Path(dpath, INFERENCE_CONFIG["raw_data"]),
+        filepath_or_buffer=Path(dpath, INFERENCE_CONFIG["data_file"]),
         index_col="note_id",
         usecols=["note_id", "full_note_norm"],
     )
@@ -159,8 +159,6 @@ if __name__ == "__main__":
 
     args: Namespace = parser.parse_args()
     with Path(args.config).open() as config_f:
-        INFERENCE_CONFIG = yaml.load(stream=config_f, Loader=yaml.FullLoader)[
-            "inference"
-        ]
+        INFERENCE_CONFIG = yaml.load(stream=config_f, Loader=yaml.FullLoader)
 
     main()


### PR DESCRIPTION
Useful if want to use the previously tuned hyperparameters with different stopwords.

* Added fixed hyperparameter training
* Refactored i/o functions to their own util file
* Refactored configuration YAML to separate files

In the future, maybe have each action (hyperparameter tuning + topic model training, fixed hyperparameter topic model training, topic model inference) as CLI options so the entry point (`main.py`) can be simplified?